### PR TITLE
Updated name of MetalVK to MoltenVK to match our product renaming.

### DIFF
--- a/api/vulkan/resources.md
+++ b/api/vulkan/resources.md
@@ -15,7 +15,7 @@ We believe the true usefulness of Vulkan goes beyond the spec itself; it is an e
 * [LunarG Vulkan SDK](https://vulkan.lunarG.com) - Official Vulkan SDK by LunarG.
 * [Google Vulkan](https://developer.android.com/go/vulkan) - Android developer website to download the API, samples, and documentation.
 * [Vulkan hardware database](http://vulkan.gpuinfo.org/) - Check out hardware capabilities and compare different Vulkan implementations.
-* [MetalVK](https://moltengl.com/metalvk/) - Vulkan implementation that uses Metal to run on iOS and OSX.
+* [MoltenVK](https://moltengl.com/moltenvk/) - Vulkan implementation that uses Metal to run on iOS and OSX.
 * [Mali Graphics Debugger](http://malideveloper.arm.com/resources/tools/mali-graphics-debugger/) - Mali debugger with Vulkan support.
 * [RenderDoc](https://github.com/baldurk/renderdoc) - Cross platform graphics debugger with Vulkan support.
 * [LWJGL](https://www.lwjgl.org/) - Light Weight Java Graphics Library with Vulkan Bindings.


### PR DESCRIPTION
We've recently changed the name of MetalVK to MoltenVK as part of a larger rebranding. I've updated the reference here to match it.