### PR TITLE
Update the link to Vulkan Windows Intel driver

### DIFF
--- a/api/vulkan/resources.md
+++ b/api/vulkan/resources.md
@@ -25,7 +25,7 @@ Khronos has placed an unprecedented amount of materials into open source so you 
 * [Imagination](https://imgtec.com/vulkan)
 * Intel:
 	- [Open Source](http://blogs.intel.com/evangelists/2016/02/16/intel-open-source-graphics-drivers-now-support-vulkan/)
-	- [Windows](https://downloadcenter.intel.com/download/26098/Intel-Graphics-Test-Driver)
+	- [Windows](https://downloadcenter.intel.com/download/26563/Graphics-Intel-Graphics-Driver-for-Windows-15-45)
 * [NVIDIA](https://developer.nvidia.com/vulkan-driver)
 * [Qualcomm](https://developer.qualcomm.com/software/adreno-gpu-sdk/gpu)
 


### PR DESCRIPTION
A new 'release' Vulkan driver have been posted by Intel.

Article: https://software.intel.com/en-us/blogs/2017/02/10/intel-announces-that-we-are-moving-from-beta-support-to-full-official-support-for