### PR TITLE
[OpenCL] Update links to SPIR-V LLVM Translator

### DIFF
--- a/api/opencl/bluebox.md
+++ b/api/opencl/bluebox.md
@@ -10,7 +10,7 @@
 * [Blog: OpenCL 2.2 Maintenance Update Released](https://www.khronos.org/blog/opencl-2.2-maintenance-update-released)
 *   [OpenCL feedback forum](https://forums.khronos.org/forumdisplay.php/87-OpenCL) offers community support for questions and feedback
 *   [SPIR-V Tools project](https://github.com/KhronosGroup/SPIRV-Tools) including an assembler, binary module parser, disassembler, and validator for SPIR-V
-*   [SPIR-V LLVM](https://github.com/KhronosGroup/SPIRV-LLVM) framework is intended to contain LLVM <-> SPIR-V converter and serve as a foundation for LLVM-based front-end compilers targeting SPIR-V.
+*   [SPIR-V LLVM Translator](https://github.com/KhronosGroup/SPIRV-LLVM-Translator) contains a LLVM <-> SPIR-V converter intended to serve as a foundation for LLVM-based front-end compilers targeting SPIR-V.
 
 ### OpenCL 2.1
 
@@ -21,7 +21,7 @@
 *   The OpenCL 2.1 Quick [Reference Guide](https://www.khronos.org/developers/reference-cards/) ( [View on SlideShare](http://www.slideshare.net/Khronos_Group/opencl-21-reference-guide) )
 *   The OpenCL 2.1 [Online Reference Pages](https://www.khronos.org/registry/OpenCL/sdk/2.1/docs/man/xhtml/)
 *   [SPIR-V Tools project](https://github.com/KhronosGroup/SPIRV-Tools) including an assembler, binary module parser, disassembler, and validator for SPIR-V
-*   [LLVM framework with SPIR-V support](https://github.com/KhronosGroup/SPIRV-LLVM) including an LLVM <-> SPIR-V bi-directional converter
+*   [SPIR-V LLVM Translator](https://github.com/KhronosGroup/SPIRV-LLVM-Translator) contains a LLVM <-> SPIR-V converter intended to serve as a foundation for LLVM-based front-end compilers targeting SPIR-V.
 *   [OpenCL Open Source Conformance Test Source](https://github.com/KhronosGroup/OpenCL-CTS/tree/cl21_trunk) contains the full source of OpenCL Conformance Tests
 
 ### OpenCL 2.1 C++

--- a/api/opencl/resources.md
+++ b/api/opencl/resources.md
@@ -10,7 +10,7 @@ We believe the true usefulness of OpenCL goes beyond the spec itself; it is an e
 * [The OpenCL C++ compiler](https://github.com/KhronosGroup/SPIR/tree/spirv-1.1) reference implementation
 * [The OpenCL C++ standard library](https://github.com/KhronosGroup/libclcxx) reference implementation
 * [SPIR-V Tools project](https://github.com/KhronosGroup/SPIRV-Tools) including an assembler, binary module parser, disassembler, and validator for SPIR-V
-* [LLVM framework with SPIR-V support](https://github.com/KhronosGroup/SPIRV-LLVM) including an LLVM <-> SPIR-V bi-directional converter
+* [SPIR-V LLVM Translator](https://github.com/KhronosGroup/SPIRV-LLVM-Translator) contains a LLVM <-> SPIR-V converter intended to serve as a foundation for LLVM-based front-end compilers targeting SPIR-V.
 * [OpenCL Forums](https://forums.khronos.org/forumdisplay.php/87-OpenCL)
 * [OpenCL Conformant Companies](https://www.khronos.org/conformance/adopters/conformant-companies#opencl)
 * [OpenCL Conformant Products](https://www.khronos.org/conformance/adopters/conformant-products/opencl)

--- a/api/spir/bluebox.md
+++ b/api/spir/bluebox.md
@@ -4,7 +4,7 @@
 *   SPIR-V 1.3 in the [Vulkan 1.1 Press Release](https://www.khronos.org/news/press/khronos-group-releases-vulkan-1-1)
 *   [SPIR-V Tools project](https://github.com/KhronosGroup/SPIRV-Tools) including an assembler, binary module parser, disassembler, optimizer, linker, and validator for SPIR-V
 *   [SPIR-V Cross](https://github.com/KhronosGroup/SPIRV-Cross) is a practical tool and library for performing reflection on SPIR-V and disassembling SPIR-V back to high level languages.
-*   [SPIR-V LLVM](https://github.com/KhronosGroup/SPIRV-LLVM) framework is intended to contain LLVM <-> SPIR-V converter and serve as a foundation for LLVM-based front-end compilers targeting SPIR-V.
+*   [SPIR-V LLVM Translator](https://github.com/KhronosGroup/SPIRV-LLVM-Translator) contains a LLVM <-> SPIR-V converter intended to serve as a foundation for LLVM-based front-end compilers targeting SPIR-V.
 *   [SPIR-V issue reporting](https://github.com/KhronosGroup/SPIRV-Headers/issues) on GitHub
 *   [SPIR-V feedback forum](https://forums.khronos.org/forumdisplay.php/113-SPIR) offers community support for questions and feedback
 

--- a/api/spir/resources.md
+++ b/api/spir/resources.md
@@ -13,7 +13,7 @@ We believe the true usefulness of OpenCL goes beyond the spec itself; it is an e
   * Extras include integration with the vim and emacs text editors and the `less` command line tool
 * Khronos Group [Glslang](https://github.com/KhronosGroup/glslang) - GLSL reference
   compiler.  It can generate SPIR-V.
-* [LLVM framework with LLVM Support](https://github.com/KhronosGroup/SPIRV-LLVM/)  including an LLVM <-> SPIR-V bi-directional converter 
+* [SPIR-V LLVM Translator](https://github.com/KhronosGroup/SPIRV-LLVM-Translator) contains a LLVM <-> SPIR-V converter intended to serve as a foundation for LLVM-based front-end compilers targeting SPIR-V.
 * [Shaderc](https://github.com/google/shaderc/) - `libshaderc` API and `glslc`
   command line wrapper around
   [Glslang](https://github.com/KhronosGroup/glslang).  `glslc` conventions


### PR DESCRIPTION
https://www.khronos.org/opencl/ was still pointing to the old
translator.

Signed-off-by: Sven van Haastregt <sven.vanhaastregt@arm.com>