### PR TITLE
Optimize SYCL URL to avoid 301 Moved Permanently on directories

### DIFF
--- a/api/sycl/README.md
+++ b/api/sycl/README.md
@@ -1,5 +1,5 @@
 # File mapping
 Files in this directory will be displayed on the Khronos.org website according to this mapping:
 
-* bluebox.md --> Bluebox information at [khronos.org/sycl](https://www.khronos.org/sycl)
-* resources.md --> [khronos.org/sycl/resources](https://www.khronos.org/sycl/resources)
+* bluebox.md --> Bluebox information at [khronos.org/sycl](https://www.khronos.org/sycl/)
+* resources.md --> [khronos.org/sycl/resources](https://www.khronos.org/sycl/resources/)

--- a/api/sycl/bluebox.md
+++ b/api/sycl/bluebox.md
@@ -8,15 +8,15 @@ feedback from developers of machine learning frameworks such as
 TensorFlow, which now supports SYCL alongside the original CUDA
 accelerator back-end.
 
-*   [SYCL 1.2.1](https://www.khronos.org/registry/SYCL)
-*   [Open-source SYCL specification files](https://github.com/KhronosGroup/SYCL-Docs)
-*   [Open-source SYCL conformance test suite](https://github.com/KhronosGroup/SYCL-CTS)
+*   [SYCL 1.2.1](https://www.khronos.org/registry/SYCL/)
+*   [Open-source SYCL specification files](https://github.com/KhronosGroup/SYCL-Docs/)
+*   [Open-source SYCL conformance test suite](https://github.com/KhronosGroup/SYCL-CTS/)
 *   [SYCL Forum](https://forums.khronos.org/showthread.php/13634-Official-SYCL-1-2-1-feedback-thread) - the best place for posting your questions and feedback
 *   [SYCL Press Release](https://www.khronos.org/news/press/the-khronos-group-releases-finalized-sycl-1.2.1)
 *   [ComputeCpp](https://www.codeplay.com/products/computesuite/computecpp) - SYCL implementation by Codeplay
 *   [triSYCL](https://github.com/triSYCL/triSYCL) - an open-source implementation to experiment with SYCL
 *   [SYCL Ecosystem Website](http://sycl.tech) - SYCL community website maintained by Codeplay
-* SYCL Adopters Program - [Adopters area](https://www.khronos.org/sycl/adopters) & [Press Release](https://www.khronos.org/news/press/khronos-releases-conformance-test-suite-for-sycl-1.2.1)
+* SYCL Adopters Program - [Adopters area](https://www.khronos.org/sycl/adopters/) & [Press Release](https://www.khronos.org/news/press/khronos-releases-conformance-test-suite-for-sycl-1.2.1)
 
 SYCL 1.2.1 builds on the features of C++11, with additional support
 for C++14 and C++17, enabling ISO C++17 Parallel STL programs to be
@@ -31,7 +31,7 @@ SG19).
 
 ### SYCL 1.2
 
-*   [SYCL 1.2](https://www.khronos.org/registry/SYCL)
+*   [SYCL 1.2](https://www.khronos.org/registry/SYCL/)
 *   [SYCL Press Release](https://www.khronos.org/news/press/khronos-releases-sycl-1.2-final-specification-c-single-source-heterogeneous)
 *   [SYCL 1.2 Overview slide](https://www.khronos.org/assets/uploads/developers/library/2015-iwocl/Khronos-SYCL-May15.pdf) (presentation slides in .pdf format)
 *   [Tutorial on using SYCL](http://codeplaysoftware.github.io/iwocl2015/) - at the May 2015 IWOCL OpenCL conference

--- a/api/sycl/resources.md
+++ b/api/sycl/resources.md
@@ -5,8 +5,8 @@ We believe the true usefulness of OpenCL goes beyond the spec itself; it is an e
 **Get involved, submit your resources either with a pull requests on [Github](https://github.com/KhronosGroup/Khronosdotorg/blob/master/api/sycl/resources.md)** or email the webmaster at Khronos.org.
 
 ## Khronos Resources
-* [Homepage](https://www.khronos.org/sycl)
-* [SYCL Registry](https://www.khronos.org/registry/SYCL)
+* [Homepage](https://www.khronos.org/sycl/)
+* [SYCL Registry](https://www.khronos.org/registry/SYCL/)
 * [SYCL Forums](https://community.khronos.org/c/opencl)
 * [SYCL Slack Channel](https://khronosdevs.slack.com/messages/CE9UX4CHG)
 * [SYCL 1.2.1 Reference Guide](https://www.khronos.org/registry/SYCL/specs/sycl-1.2.1.pdf)


### PR DESCRIPTION
As suggested by James Riordon, avoid an intermediate redirection such
as

wget --verbose  https://www.khronos.org/registry/SYCL
--2020-04-28 06:29:00--  https://www.khronos.org/registry/SYCL
Resolving www.khronos.org (www.khronos.org)... 104.236.24.254
Connecting to www.khronos.org (www.khronos.org)|104.236.24.254|:443... connected.
HTTP request sent, awaiting response... 301 Moved Permanently
Location: https://www.khronos.org/registry/SYCL/ [following]
--2020-04-28 06:29:00--  https://www.khronos.org/registry/SYCL/
Reusing existing connection to www.khronos.org:443.
HTTP request sent, awaiting response... 200 OK

by adding a `/` at the end of the URL when possible.