### PR TITLE
Update the link for OpenCL offline compilation page.

### DIFF
--- a/api/opencl/resources.md
+++ b/api/opencl/resources.md
@@ -31,7 +31,7 @@ List of individual tools supporting OpenCL and SPIR-V:
 *   The open source [clspv compiler](https://github.com/google/clspv) and [clvk runtime layer](https://github.com/kpet/clvk) enable OpenCL applications to be executed on Vulkan
 *   [SPIR-V Tools](https://github.com/KhronosGroup/SPIRV-Tools) provide a set of utilities to process SPIR-V modules including an optimizer, linker, (dis-)assembler, and validator
 
-This [blog](https://www.khronos.org/blog/offline-compilation-of-opencl-kernels-into-spir-v-using-open-source-tooling) contains a detailed description of how to compile OpenCL kernels offline into SPIR-V using the available open source tools.
+[OpenCL-Guide](https://github.com/KhronosGroup/OpenCL-Guide/blob/main/chapters/os_tooling.md) contains a detailed description of how to compile OpenCL kernels offline into SPIR-V using the available open source tools.
 
 ### OpenCL Development Tools
 


### PR DESCRIPTION
The detailed information for offline compilation
and tools is now part of OpenCL-Guide and expected
to be kept up to date there.